### PR TITLE
Add install script and manual release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,13 +4,54 @@ on:
   push:
     tags:
       - "v*.*.*"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to release (e.g. 0.1.0)"
+        required: true
+        type: string
+      dry_run:
+        description: "Dry run (build only, no release)"
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
 
 jobs:
+  prepare:
+    name: Prepare
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.version.outputs.version }}
+      tag: ${{ steps.version.outputs.tag }}
+    steps:
+      - name: Resolve version
+        id: version
+        shell: bash
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_VERSION: ${{ inputs.version }}
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            VERSION="$INPUT_VERSION"
+          else
+            VERSION="${REF_NAME#v}"
+          fi
+          # Validate version format
+          if ! echo "$VERSION" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$'; then
+            echo "::error::Invalid version format: $VERSION (expected semver like 0.1.0)"
+            exit 1
+          fi
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "Releasing v${VERSION}"
+
   build:
     name: Build (${{ matrix.os }})
+    needs: prepare
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -32,16 +73,17 @@ jobs:
 
       - name: Package
         shell: bash
+        env:
+          RUNNER_OS_NAME: ${{ matrix.os }}
         run: |
           set -euo pipefail
           mkdir -p dist
-          OS="${{ matrix.os }}"
-          if [ "$OS" = "ubuntu-latest" ]; then
+          if [ "$RUNNER_OS_NAME" = "ubuntu-latest" ]; then
             OS_NAME=linux
-          elif [ "$OS" = "macos-latest" ]; then
+          elif [ "$RUNNER_OS_NAME" = "macos-latest" ]; then
             OS_NAME=macos
           else
-            OS_NAME="$OS"
+            OS_NAME="$RUNNER_OS_NAME"
           fi
           ARCH=$(uname -m)
           ARCHIVE="saw-${OS_NAME}-${ARCH}.tar.gz"
@@ -62,12 +104,24 @@ jobs:
 
   release:
     name: Publish Release
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
     runs-on: ubuntu-latest
-    needs: build
+    needs: [prepare, build]
     permissions:
       contents: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Create tag (manual trigger)
+        if: ${{ github.event_name == 'workflow_dispatch' }}
+        env:
+          TAG: ${{ needs.prepare.outputs.tag }}
+        run: |
+          git tag "$TAG"
+          git push origin "$TAG"
+
       - name: Download Artifacts
         uses: actions/download-artifact@v4
         with:
@@ -91,6 +145,8 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ needs.prepare.outputs.tag }}
+          generate_release_notes: true
           files: |
             release/*.tar.gz
             release/sha256sums.txt

--- a/README.md
+++ b/README.md
@@ -39,12 +39,16 @@ flowchart LR
 
 **Installation**
 
-Download the latest release:
+One-liner (recommended):
 ```bash
-# Download and extract the release (replace VERSION and ARCH)
-curl -LO https://github.com/daydreamsai/agent-wallet/releases/download/vVERSION/saw-VERSION-linux-x86_64.tar.gz
-tar xzf saw-VERSION-linux-x86_64.tar.gz
-sudo cp saw saw-daemon /usr/local/bin/
+curl -sSL https://raw.githubusercontent.com/daydreamsai/agent-wallet/master/install.sh | sh
+```
+
+This detects your OS/arch, downloads the latest release, and sets up `~/.saw/`.
+
+Or install a specific version:
+```bash
+SAW_VERSION=0.1.0 curl -sSL https://raw.githubusercontent.com/daydreamsai/agent-wallet/master/install.sh | sh
 ```
 
 Or build from source:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,187 @@
+#!/bin/sh
+# install.sh — one-liner installer for Secure Agent Wallet (SAW)
+#
+# Usage:
+#   curl -sSL https://raw.githubusercontent.com/daydreamsai/agent-wallet/master/install.sh | sh
+#
+# Options (via environment variables):
+#   SAW_VERSION   - specific version to install (e.g. "0.1.0"), default: latest
+#   SAW_INSTALL   - install directory, default: ~/.saw/bin
+#   SAW_ROOT      - data directory, default: ~/.saw
+
+set -eu
+
+REPO="daydreamsai/agent-wallet"
+INSTALL_DIR="${SAW_INSTALL:-$HOME/.saw/bin}"
+SAW_ROOT="${SAW_ROOT:-$HOME/.saw}"
+
+# --- helpers ---------------------------------------------------------------
+
+info()  { printf '  \033[1;34m>\033[0m %s\n' "$*"; }
+ok()    { printf '  \033[1;32m✓\033[0m %s\n' "$*"; }
+err()   { printf '  \033[1;31m✗\033[0m %s\n' "$*" >&2; }
+bold()  { printf '\033[1m%s\033[0m\n' "$*"; }
+
+need() {
+  if ! command -v "$1" > /dev/null 2>&1; then
+    err "Required tool '$1' not found. Please install it and retry."
+    exit 1
+  fi
+}
+
+# --- detect platform -------------------------------------------------------
+
+detect_platform() {
+  OS="$(uname -s)"
+  ARCH="$(uname -m)"
+
+  case "$OS" in
+    Linux)  OS_NAME="linux" ;;
+    Darwin) OS_NAME="macos" ;;
+    *)
+      err "Unsupported OS: $OS (SAW requires Linux or macOS)"
+      exit 1
+      ;;
+  esac
+
+  case "$ARCH" in
+    x86_64|amd64)   ARCH="x86_64" ;;
+    arm64|aarch64)   ARCH="arm64"  ;;
+    *)
+      err "Unsupported architecture: $ARCH"
+      exit 1
+      ;;
+  esac
+
+  ARCHIVE="saw-${OS_NAME}-${ARCH}.tar.gz"
+}
+
+# --- resolve version -------------------------------------------------------
+
+resolve_version() {
+  if [ -n "${SAW_VERSION:-}" ]; then
+    VERSION="$SAW_VERSION"
+    info "Using requested version: v${VERSION}"
+  else
+    info "Fetching latest release..."
+    VERSION=$(curl -sSL -H "Accept: application/json" \
+      "https://api.github.com/repos/${REPO}/releases/latest" \
+      | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"v\([^"]*\)".*/\1/p')
+
+    if [ -z "$VERSION" ]; then
+      err "Could not determine latest version."
+      err "Set SAW_VERSION explicitly, e.g.:"
+      err "  SAW_VERSION=0.1.0 curl -sSL ... | sh"
+      exit 1
+    fi
+    info "Latest version: v${VERSION}"
+  fi
+
+  DOWNLOAD_URL="https://github.com/${REPO}/releases/download/v${VERSION}/${ARCHIVE}"
+}
+
+# --- download & install ----------------------------------------------------
+
+download_and_install() {
+  TMPDIR="$(mktemp -d)"
+  trap 'rm -rf "$TMPDIR"' EXIT
+
+  info "Downloading ${ARCHIVE}..."
+  HTTP_CODE=$(curl -sSL -w '%{http_code}' -o "${TMPDIR}/${ARCHIVE}" "$DOWNLOAD_URL")
+
+  if [ "$HTTP_CODE" != "200" ]; then
+    err "Download failed (HTTP ${HTTP_CODE})"
+    err "URL: ${DOWNLOAD_URL}"
+    err ""
+    err "If this is the first release, you may need to publish one first:"
+    err "  git tag v0.1.0 && git push origin v0.1.0"
+    exit 1
+  fi
+
+  info "Extracting..."
+  tar xzf "${TMPDIR}/${ARCHIVE}" -C "$TMPDIR"
+
+  mkdir -p "$INSTALL_DIR"
+  cp "${TMPDIR}/saw"        "$INSTALL_DIR/saw"
+  cp "${TMPDIR}/saw-daemon"  "$INSTALL_DIR/saw-daemon"
+  chmod +x "$INSTALL_DIR/saw" "$INSTALL_DIR/saw-daemon"
+
+  ok "Installed saw and saw-daemon to ${INSTALL_DIR}"
+}
+
+# --- post-install setup ----------------------------------------------------
+
+setup() {
+  # Run saw install to create directory layout
+  if "${INSTALL_DIR}/saw" install --root "$SAW_ROOT" 2>/dev/null; then
+    ok "Initialized data directory at ${SAW_ROOT}"
+  else
+    info "Data directory already exists at ${SAW_ROOT}"
+  fi
+}
+
+# --- PATH advice -----------------------------------------------------------
+
+ensure_path() {
+  case ":${PATH}:" in
+    *":${INSTALL_DIR}:"*) return ;;
+  esac
+
+  bold ""
+  bold "Add SAW to your PATH:"
+  echo ""
+
+  SHELL_NAME="$(basename "${SHELL:-/bin/sh}")"
+  case "$SHELL_NAME" in
+    zsh)  RC_FILE="~/.zshrc" ;;
+    bash) RC_FILE="~/.bashrc" ;;
+    fish) RC_FILE="~/.config/fish/config.fish" ;;
+    *)    RC_FILE="your shell's rc file" ;;
+  esac
+
+  if [ "$SHELL_NAME" = "fish" ]; then
+    echo "  fish_add_path ${INSTALL_DIR}"
+  else
+    echo "  export PATH=\"${INSTALL_DIR}:\$PATH\""
+  fi
+  echo ""
+  echo "  Add that line to ${RC_FILE} to make it permanent."
+}
+
+# --- main ------------------------------------------------------------------
+
+main() {
+  bold ""
+  bold "  Secure Agent Wallet (SAW) Installer"
+  bold ""
+
+  need curl
+  need tar
+
+  detect_platform
+  info "Platform: ${OS_NAME}/${ARCH}"
+
+  resolve_version
+  download_and_install
+  setup
+
+  bold ""
+  bold "  Next steps:"
+  echo ""
+  echo "  1. Generate a wallet:"
+  echo "     saw gen-key --chain evm --wallet main"
+  echo ""
+  echo "  2. Edit your policy:"
+  echo "     \$EDITOR ~/.saw/policy.yaml"
+  echo ""
+  echo "  3. Start the daemon:"
+  echo "     saw-daemon"
+  echo ""
+
+  ensure_path
+
+  bold "  Docs: https://github.com/${REPO}"
+  bold ""
+}
+
+main


### PR DESCRIPTION
## Summary
- Added install.sh: one-liner installer for easy distribution (`curl -sSL https://... | sh`)
- Enhanced release workflow to support manual triggering via workflow_dispatch
- Added version validation and auto-tagging for manual releases
- Improved GitHub Actions security by using env vars instead of inline interpolation

## Install script features
- Auto-detects OS (linux/macos) and architecture (x86_64/arm64)
- Fetches latest release from GitHub API
- Installs binaries to `~/.saw/bin/` and runs setup
- Configurable via SAW_VERSION, SAW_INSTALL, SAW_ROOT env vars

## Release workflow improvements
- Two trigger modes: git tags (existing) + manual workflow dispatch (new)
- Manual trigger with optional dry-run mode
- Auto-generates release notes
- Safe input handling for GitHub Actions

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>