### PR TITLE
Add NPM publishing to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,43 @@ jobs:
           name: ${{ env.ARCHIVE }}
           path: dist/${{ env.ARCHIVE }}
 
+  npm-publish:
+    name: Publish NPM Package
+    if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}
+    runs-on: ubuntu-latest
+    needs: prepare
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set package version
+        working-directory: packages/saw
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+        run: npm version "$RELEASE_VERSION" --no-git-tag-version
+
+      - name: Install dependencies
+        working-directory: packages/saw
+        run: npm ci
+
+      - name: Build
+        working-directory: packages/saw
+        run: npm run build
+
+      - name: Publish
+        working-directory: packages/saw
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
   release:
     name: Publish Release
     if: ${{ !(github.event_name == 'workflow_dispatch' && inputs.dry_run) }}


### PR DESCRIPTION
Publish @daydreamsai/saw to npm alongside binary releases.

The new `npm-publish` job runs in parallel with binary builds, automatically syncing the package version and publishing with public access. Respects dry-run mode.

Requires: Set `NPM_TOKEN` secret in repository settings before release.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced release workflow automation to streamline package publishing process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->