### PR TITLE
Configure npm package for publishing

### DIFF
--- a/packages/saw/LICENSE
+++ b/packages/saw/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 Daydreams AI
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/packages/saw/package-lock.json
+++ b/packages/saw/package-lock.json
@@ -884,7 +884,6 @@
       "integrity": "sha512-5jsi0wpncvTD33Sh1UCgacK37FFwDn+EG7wCmEvs62fCvBL+n8/76cAYDok21NF6+jaVWIqKwCZyX7Vbu8eB3A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -1141,7 +1140,6 @@
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "esbuild": "bin/esbuild"
       },
@@ -1384,7 +1382,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -1434,7 +1431,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -1760,7 +1756,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -1789,7 +1784,6 @@
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",

--- a/packages/saw/package.json
+++ b/packages/saw/package.json
@@ -2,11 +2,38 @@
   "name": "@daydreamsai/saw",
   "version": "0.1.0",
   "type": "module",
-  "description": "Node.js client for Secure Agent Wallet (SAW)",
+  "description": "Node.js client for Secure Agent Wallet (SAW) — sign EVM/Solana payloads without exposing private keys",
   "license": "MIT",
+  "author": "Daydreams AI",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/daydreamsai/agent-wallet.git",
+    "directory": "packages/saw"
+  },
+  "homepage": "https://github.com/daydreamsai/agent-wallet/tree/master/packages/saw#readme",
+  "bugs": {
+    "url": "https://github.com/daydreamsai/agent-wallet/issues"
+  },
+  "keywords": [
+    "wallet",
+    "agent",
+    "evm",
+    "solana",
+    "signing",
+    "eip2612",
+    "permit",
+    "crypto"
+  ],
+  "sideEffects": false,
+  "engines": {
+    "node": ">=18"
+  },
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "README.md"
+    "README.md",
+    "LICENSE"
   ],
   "exports": {
     ".": {
@@ -16,6 +43,7 @@
   },
   "scripts": {
     "build": "tsup",
+    "prepublishOnly": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest"
   },


### PR DESCRIPTION
## Summary

Prepares the @daydreamsai/saw npm package for reliable publishing:

- **Repository metadata**: Added author, homepage, bugs URL, and repository link with package directory
- **Discoverability**: Added keywords (wallet, agent, evm, solana, signing, eip2612, permit, crypto)
- **Build safety**: Added prepublishOnly hook to ensure build runs before npm publish
- **Tree-shaking**: Added sideEffects: false for bundler optimization
- **Compatibility**: Added top-level main/types fields for backwards compatibility with older tools
- **Engine constraint**: Specified Node >=18 requirement
- **Licensing**: Created and distributed MIT LICENSE file

## Changes

| File | Details |
|------|---------|
| package.json | Repository metadata, keywords, engines, tree-shaking flag, build hook |
| LICENSE | MIT license file (new) |
| package-lock.json | Peer dependency flag cleanup during npm ci |

## Verification

- [x] Package builds successfully
- [x] All tests pass (4/4)
- [x] npm pack shows correct files included
- [x] No breaking changes to client API

The existing GitHub release workflow already handles versioning and npm publish with public access, so this package is now ready for production releases.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added MIT License for the package
  * Updated package metadata and entry points
  * Established Node.js 18+ as minimum required version
  * Configured package for proper distribution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->