### PR TITLE
installer: fix macOS SAW setup + rerun idempotency

### DIFF
--- a/tests/install-sh-unit.sh
+++ b/tests/install-sh-unit.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+fail() {
+  echo "FAIL: $*" >&2
+  exit 1
+}
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+echo "==> case: macOS setup fallback creates layout"
+(
+  case_dir="${TMP_DIR}/mac-fallback"
+  install_dir="${case_dir}/bin"
+  saw_root="${case_dir}/root"
+  mkdir -p "${install_dir}"
+
+  export SAW_INSTALL_SH_NO_RUN=1
+  export SAW_INSTALL="${install_dir}"
+  export SAW_ROOT="${saw_root}"
+  # shellcheck source=../install.sh
+  source "${ROOT_DIR}/install.sh"
+
+  OS_NAME="macos"
+  cat > "${install_dir}/saw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "adduser: command not found" >&2
+exit 1
+EOF
+  chmod +x "${install_dir}/saw"
+
+  setup
+
+  [[ -d "${saw_root}/keys" ]] || fail "expected keys directory to be created"
+  [[ -f "${saw_root}/policy.yaml" ]] || fail "expected policy.yaml to be created"
+  [[ -f "${saw_root}/audit.log" ]] || fail "expected audit.log to be created"
+)
+
+echo "==> case: macOS setup fallback is idempotent"
+(
+  case_dir="${TMP_DIR}/mac-rerun"
+  install_dir="${case_dir}/bin"
+  saw_root="${case_dir}/root"
+  mkdir -p "${install_dir}"
+
+  export SAW_INSTALL_SH_NO_RUN=1
+  export SAW_INSTALL="${install_dir}"
+  export SAW_ROOT="${saw_root}"
+  # shellcheck source=../install.sh
+  source "${ROOT_DIR}/install.sh"
+
+  OS_NAME="macos"
+  cat > "${install_dir}/saw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "${install_dir}/saw"
+
+  setup
+  setup
+
+  grep -q "^wallets:" "${saw_root}/policy.yaml" || fail "expected policy.yaml skeleton"
+)
+
+echo "==> case: linux setup failure without existing root returns non-zero"
+if (
+  case_dir="${TMP_DIR}/linux-fail"
+  install_dir="${case_dir}/bin"
+  saw_root="${case_dir}/root"
+  mkdir -p "${install_dir}"
+
+  export SAW_INSTALL_SH_NO_RUN=1
+  export SAW_INSTALL="${install_dir}"
+  export SAW_ROOT="${saw_root}"
+  # shellcheck source=../install.sh
+  source "${ROOT_DIR}/install.sh"
+
+  OS_NAME="linux"
+  cat > "${install_dir}/saw" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+exit 1
+EOF
+  chmod +x "${install_dir}/saw"
+
+  setup
+); then
+  fail "expected linux setup failure to exit non-zero"
+fi
+
+echo "OK"


### PR DESCRIPTION
## Summary
- make `install.sh` resilient on macOS when `saw install` fails due Linux-only setup internals
- add a macOS fallback that initializes `~/.saw` layout directly (`keys`, `policy.yaml`, `audit.log`)
- keep reruns idempotent and preserve Linux fail-fast behavior when setup truly cannot initialize
- add a `SAW_INSTALL_SH_NO_RUN` guard to allow sourcing in unit tests
- add shell unit tests for macOS fallback + rerun idempotency

## Testing
- `bash tests/install-sh-unit.sh`
- `bash -n install.sh && bash -n tests/install-sh-unit.sh`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved installation process with enhanced macOS support and refined error handling during initialization.
  * Setup is now more robust with fallback mechanisms and clearer error reporting.

* **Tests**
  * Added comprehensive unit test coverage for the installation workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->